### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tool for EPUB maintained by [DAISY Consortium](https://daisy.org/) on behalf of 
 [W3C](https://www.w3.org/publishing/epubcheck_fundraising), originally developed by the
 [IDPF](http://idpf.org/).
 
-This package provides a Python libary and command line tool for convenient validation of EPUB files
+This package provides a Python library and command line tool for convenient validation of EPUB files
 by wrapping the original [EpubCheck 4.2.6](https://github.com/w3c/epubcheck/releases/tag/v4.2.6).
 
 - Free software: BSD license
@@ -35,7 +35,7 @@ PyPy.
 
 ### Command line usage examples
 
-Validata all epub files in the current directory:
+Validate all epub files in the current directory:
 
 ```
 $ epubcheck
@@ -113,7 +113,7 @@ poe all
 
 ### 0.3.1 - 2016-04-20
 
-- Added custom PY2/PY3 compat module and removed dependancy on six
+- Added custom PY2/PY3 compat module and removed dependency on six
 
 ### 0.3.0 - 2016-04-10
 

--- a/epubcheck/CHANGELOG.txt
+++ b/epubcheck/CHANGELOG.txt
@@ -88,7 +88,7 @@ This EPUBCheck version is also available in the Maven Central Repository as [`or
 * better check media overlays styling properties ([6a58b8e](https://github.com/w3c/epubcheck/commit/6a58b8e))
 * better parse URL fragment micro syntaxes ([bec390e](https://github.com/w3c/epubcheck/commit/bec390e))
 * check `epub:type` restrictions in XHTML and SVG ([0fab5c8](https://github.com/w3c/epubcheck/commit/0fab5c8)), closes [#1348](https://github.com/w3c/epubcheck/issues/1348)
-* check file name uniqueness wiht Unicode canonical case fold normalization ([111e772](https://github.com/w3c/epubcheck/commit/111e772)), closes [#1246](https://github.com/w3c/epubcheck/issues/1246)
+* check file name uniqueness with Unicode canonical case fold normalization ([111e772](https://github.com/w3c/epubcheck/commit/111e772)), closes [#1246](https://github.com/w3c/epubcheck/issues/1246)
 * check fragment requirements on overlays links to text content ([2091d14](https://github.com/w3c/epubcheck/commit/2091d14)), closes [#1248](https://github.com/w3c/epubcheck/issues/1248) [#1301](https://github.com/w3c/epubcheck/issues/1301)
 * check that container-relative URLs have no query ([a4fed67](https://github.com/w3c/epubcheck/commit/a4fed67))
 * check that overlays audio file URLs have no fragments ([fdabe66](https://github.com/w3c/epubcheck/commit/fdabe66)), closes [#1251](https://github.com/w3c/epubcheck/issues/1251)
@@ -261,7 +261,7 @@ This EPUBCheck version is also available in the Maven Central Repository as [`or
 * downgrade RSC-004 (cannot decrypt resource) to INFO ([#1136](https://github.com/w3c/epubcheck/issues/1136)) ([e732068](https://github.com/w3c/epubcheck/commit/e732068))
 * report empty `title` elements in XHTML Content Documents ([#1135](https://github.com/w3c/epubcheck/issues/1135)) ([f115730](https://github.com/w3c/epubcheck/commit/f115730)), closes [#1093](https://github.com/w3c/epubcheck/issues/1093)
 * **ARIA:** allow doc-epigraph on 'section' and doc-cover on 'img' ([84a0979](https://github.com/w3c/epubcheck/commit/84a0979))
-* update the XML ouput to the new JHOVE schema ([0b346fd](https://github.com/w3c/epubcheck/commit/0b346fd)) (thanks @tledoux!)
+* update the XML output to the new JHOVE schema ([0b346fd](https://github.com/w3c/epubcheck/commit/0b346fd)) (thanks @tledoux!)
 
 ### Bug Fixes
 

--- a/epubcheck/checker.py
+++ b/epubcheck/checker.py
@@ -13,7 +13,7 @@ class EpubCheck:
     :param str infile: path to epubfile to be checked
     :param str lang: set language for generated messages
     :param str profile: name of epubcheck profule to use
-    :param bool autorun: wether to run the checking process on instantiation.
+    :param bool autorun: weather to run the checking process on instantiation.
     """
 
     DEFAULT = "default"

--- a/epubcheck/checker.py
+++ b/epubcheck/checker.py
@@ -13,7 +13,7 @@ class EpubCheck:
     :param str infile: path to epubfile to be checked
     :param str lang: set language for generated messages
     :param str profile: name of epubcheck profule to use
-    :param bool autorun: weather to run the checking process on instantiation.
+    :param bool autorun: whether to run the checking process on instantiation.
     """
 
     DEFAULT = "default"

--- a/epubcheck/samples/help.txt
+++ b/epubcheck/samples/help.txt
@@ -43,7 +43,7 @@ This tool also accepts the following options:
                            1 if either warnings or errors are present and 0 only when there are no errors or warnings.
 -q, --quiet              = no message on console, except errors, only in the output
 -f, --fatal              = include only fatal errors in the output
--e, --error              = include only error and fatal severity messages in ouput
+-e, --error              = include only error and fatal severity messages in output
 -w, --warn               = include fatal, error, and warn severity messages in output
 -u, --usage              = include ePub feature usage information in output
                            (default is OFF); if enabled, usage information will

--- a/epubcheck/utils.py
+++ b/epubcheck/utils.py
@@ -65,7 +65,7 @@ def iter_files(root, exts=None, recursive=False):
     Iterate over file paths within root filtered by specified extensions.
     :param compat.string_types root: Root folder to start collecting files
     :param iterable exts: Restrict results to given file extensions
-    :param bool recursive: Wether to walk the complete directory tree
+    :param bool recursive: Weather to walk the complete directory tree
     :rtype collections.Iterable[str]: absolute file paths with given extensions
     """
 

--- a/epubcheck/utils.py
+++ b/epubcheck/utils.py
@@ -65,7 +65,7 @@ def iter_files(root, exts=None, recursive=False):
     Iterate over file paths within root filtered by specified extensions.
     :param compat.string_types root: Root folder to start collecting files
     :param iterable exts: Restrict results to given file extensions
-    :param bool recursive: Weather to walk the complete directory tree
+    :param bool recursive: Whether to walk the complete directory tree
     :rtype collections.Iterable[str]: absolute file paths with given extensions
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ line-length = 100
 line-ending = "lf"
 
 [tool.poe.tasks]
-format-code = { cmd = "poetry run ruff format", help = "Code style formating with ruff" }
-format-markdown = { cmd = "mdformat --wrap 100 --end-of-line lf .", help = "Markdown formating with mdformat" }
+format-code = { cmd = "poetry run ruff format", help = "Code style formatting with ruff" }
+format-markdown = { cmd = "mdformat --wrap 100 --end-of-line lf .", help = "Markdown formatting with mdformat" }
 test = { cmd = "poetry run pytest --cov=epubcheck --cov-fail-under=100 --cov-report=term-missing", help = "Run tests with coverage" }
 all = ["format-code", "format-markdown", "test"]
 


### PR DESCRIPTION
Found via `codespell -L ois`